### PR TITLE
fix(flat): remove unused deprecation plugin import

### DIFF
--- a/flat.mjs
+++ b/flat.mjs
@@ -4,7 +4,6 @@ import jsxA11y from "eslint-plugin-jsx-a11y";
 import sortPlugin from "eslint-plugin-sort";
 import jestPlugin from "eslint-plugin-jest";
 import tanstackQueryPlugin from "@tanstack/eslint-plugin-query";
-import deprecationPlugin from "eslint-plugin-deprecation";
 
 export default [
   // Spread Grafana's base config

--- a/flat.mjs
+++ b/flat.mjs
@@ -4,6 +4,9 @@ import jsxA11y from "eslint-plugin-jsx-a11y";
 import sortPlugin from "eslint-plugin-sort";
 import jestPlugin from "eslint-plugin-jest";
 import tanstackQueryPlugin from "@tanstack/eslint-plugin-query";
+// Note: eslint-plugin-deprecation is intentionally excluded from the flat config.
+// It bundles an older @typescript-eslint/utils that references LegacyESLint (removed in ESLint 10).
+// Use @typescript-eslint/no-deprecated (available in @typescript-eslint v7+) directly in your eslint.config.mjs instead.
 
 export default [
   // Spread Grafana's base config

--- a/package.json
+++ b/package.json
@@ -48,5 +48,10 @@
     "prettier": "^3.4.2",
     "typescript": "^5.9.3"
   },
+  "peerDependenciesMeta": {
+    "eslint-plugin-deprecation": {
+      "optional": true
+    }
+  },
   "packageManager": "yarn@4.6.0"
 }


### PR DESCRIPTION
## Summary

- Removes unused `eslint-plugin-deprecation` import from `flat.mjs`
- `eslint-plugin-deprecation@3` bundles an older `@typescript-eslint/utils` that references `LegacyESLint`, which was removed in ESLint 10 — importing the plugin crashes ESLint 10 even though it was never used in any config object
- Consuming projects should use `@typescript-eslint/no-deprecated` (the modern equivalent, available in `@typescript-eslint` v7+) directly in their own `eslint.config.mjs`

## Test plan

- [x] Verify `flat.mjs` works without errors under ESLint 10
- [x] Confirm consuming projects can use `@typescript-eslint/no-deprecated` as the replacement rule